### PR TITLE
feat: custom render arrow and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export default function AwesomeScreen() {
 ```
 
 ## Example
+
 [![preview](https://i.ibb.co/n3VpkY4/Screen-Shot-2018-12-04-at-13-53-26.png)](https://snack.expo.io/@jekiwijaya/react-native-coachmark)
 
 [View on Expo!](https://snack.expo.io/@jekiwijaya/react-native-coachmark)
@@ -49,36 +50,42 @@ export default function AwesomeScreen() {
 ### - Coachmark
 
 #### Importing
-```javascript
-var Coachmark = require('react-native-coachmark').Coachmark;  // ES5
 
-import { Coachmark } from 'react-native-coachmark';  // ES6
+```javascript
+var Coachmark = require('react-native-coachmark').Coachmark; // ES5
+
+import { Coachmark } from 'react-native-coachmark'; // ES6
 ```
 
 #### Props
-| Property      | Type     | Default Value | Description                                    |
-| ------------- | -------- | ------------- | ---------------------------------------------- |
-| message       | string   | none          | required                                       |
-| autoShow      | boolean  | none          | to show the coachmark when mounting            |
-| onShow        | function | none          | will be called when coachmark is showing       |
-| onHide        | function | none          | will be called when coachmark is hidden        |
-| isAnchorReady | boolean  | true          | a value to force coachmark not being shown yet |
+
+| Property         | Type     | Default Value | Description                                    |
+| ---------------- | -------- | ------------- | ---------------------------------------------- |
+| message          | string   | none          | required                                       |
+| autoShow         | boolean  | none          | to show the coachmark when mounting            |
+| showArrow        | boolean  | true          | to show the arrow in the coachmark             |
+| coachmarkContent | function | null          | to show a custom content for coachmark         |
+| onShow           | function | none          | will be called when coachmark is showing       |
+| onHide           | function | none          | will be called when coachmark is hidden        |
+| isAnchorReady    | boolean  | true          | a value to force coachmark not being shown yet |
 
 #### Methods
 
-| Methods             | Description                              |
-| ------------------- | ---------------------------------------- |
-| `show() => Promise` | a function to trigger show the coachmark |
+| Methods                      | Description                               |
+| ---------------------------- | ----------------------------------------- |
+| `show() => Promise`          | a function to trigger show the coachmark  |
+| `coachmarkContent() => null` | a function to render content in coachmark |
 
 ### Roadmap
+
 - [ ] Auto load and save in AsyncStorage
 - [x] Show coachmark only when in view port
 - [ ] Custom render arrow and content
-
 
 ## Contributing
 
 We'd to have your helping hand on this package! Feel free to PR's, add issues or give feedback!
 
 ## Credits
+
 Written by [Jacky Wijaya](https://www.linkedin.com/in/jacky-wijaya-125b90b6/) (jekiwijaya) at Traveloka.

--- a/src/components/Coachmark.tsx
+++ b/src/components/Coachmark.tsx
@@ -18,6 +18,8 @@ interface CoachmarkState {
 export default class Coachmark extends Component<CoachmarkProps, CoachmarkState> {
   static defaultProps: CoachmarkProps = {
     autoShow: false,
+    showArrow: true,
+    coachmarkContent: null,
     onHide: () => {}, // eslint-disable-line no-empty-function
     onShow: () => {}, // eslint-disable-line no-empty-function
     isAnchorReady: true,

--- a/src/components/Coachmark.tsx
+++ b/src/components/Coachmark.tsx
@@ -151,6 +151,8 @@ export default class Coachmark extends Component<CoachmarkProps, CoachmarkState>
           position={this.state.position}
           message={this.props.message!}
           renderArrow={this.props.renderArrow}
+          coachmarkContent={this.props.coachmarkContent}
+          showArrow={this.props.showArrow}
         />
       </View>
     );

--- a/src/components/CoachmarkContent.tsx
+++ b/src/components/CoachmarkContent.tsx
@@ -3,10 +3,12 @@ import { Text, View, StyleSheet } from 'react-native';
 import { CoachmarkContentProps } from '../types';
 
 export default class CoachmarkContent extends Component<CoachmarkContentProps> {
-  static defaultProps: Pick<CoachmarkContentProps, 'buttonText'> = {
+  static defaultProps: Pick<CoachmarkContentProps, 'buttonText' | 'coachmarkContent'> = {
     buttonText: 'OK',
+    coachmarkContent: null,
   };
   render() {
+    if (this.props.coachmarkContent) return this.props.coachmarkContent();
     return (
       <View style={styles.container}>
         <View style={styles.message}>

--- a/src/components/CoachmarkView.tsx
+++ b/src/components/CoachmarkView.tsx
@@ -15,7 +15,10 @@ export default class CoachmarkView extends Component<CoachmarkViewProps> {
   }
 
   renderCoachmarkArrow() {
-    const { renderArrow, x, position } = this.props;
+    const { renderArrow, x, position, showArrow } = this.props;
+    if (!showArrow) {
+      return null;
+    }
     return renderArrow({ x, position });
   }
 

--- a/src/components/CoachmarkView.tsx
+++ b/src/components/CoachmarkView.tsx
@@ -4,13 +4,14 @@ import CoachmarkArrow from './CoachmarkArrow';
 import { CoachmarkPosition, CoachmarkViewProps } from '../types';
 
 export default class CoachmarkView extends Component<CoachmarkViewProps> {
-  static defaultProps: Pick<CoachmarkViewProps, 'position' | 'renderArrow'> = {
+  static defaultProps: Pick<CoachmarkViewProps, 'position' | 'coachmarkContent' | 'renderArrow'> = {
     position: CoachmarkPosition.TOP,
+    coachmarkContent: null,
     renderArrow: ({ x, position }) => <CoachmarkArrow x={x} position={position} />,
   };
 
   renderCoachmarkContent() {
-    return <CoachmarkContent message={this.props.message} />;
+    return <CoachmarkContent message={this.props.message} coachmarkContent={this.props.coachmarkContent} />;
   }
 
   renderCoachmarkArrow() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import { StyleProp, ViewStyle } from 'react-native';
 export interface CoachmarkProps {
   message?: string;
   autoShow?: boolean;
+  showArrow: boolean;
+  coachmarkContent?: (() => void) | null;
   onHide?: () => void;
   onShow?: () => void;
   isAnchorReady?: boolean;
@@ -26,9 +28,11 @@ export interface CoachmarkArrowProps {
 export interface CoachmarkContentProps {
   message: string;
   buttonText?: string;
+  coachmarkContent?: (() => void) | null;
 }
 
 export type CoachmarkViewProps = {
+  coachmarkContent: (() => void) | null;
   renderArrow: ({
     x,
     position,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface CoachmarkProps {
   message?: string;
   autoShow?: boolean;
   showArrow: boolean;
-  coachmarkContent?: (() => void) | null;
+  coachmarkContent: (() => React.Component) | null;
   onHide?: () => void;
   onShow?: () => void;
   isAnchorReady?: boolean;
@@ -28,11 +28,12 @@ export interface CoachmarkArrowProps {
 export interface CoachmarkContentProps {
   message: string;
   buttonText?: string;
-  coachmarkContent?: (() => void) | null;
+  coachmarkContent: (() => React.Component) | null;
 }
 
 export type CoachmarkViewProps = {
-  coachmarkContent: (() => void) | null;
+  showArrow?: boolean;
+  coachmarkContent?: (() => React.Component) | null;
   renderArrow: ({
     x,
     position,


### PR DESCRIPTION
Please merge it at the earliest will contribute more if merged also this is in your road map.
Here is a screenshot of the sample custom content being rendered by react-native-coachmark.
<img width="433" alt="Screenshot 2021-03-24 at 8 20 16 PM" src="https://user-images.githubusercontent.com/34180254/112330775-5a448380-8cde-11eb-9dbf-ecece4e21a2c.png">
