### PR TITLE
feat: add renderContent to props

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import { Coachmark } from 'react-native-coachmark'; // ES6
 
 | Property      | Type               | Default Value | Description                                                 |
 | ------------- | ------------------ | ------------- | ----------------------------------------------------------- |
-| message       | string             | none          | required                                                    |
+| message       | string             | none          | optional                                                    |
 | autoShow      | boolean            | none          | to show the coachmark when mounting                         |
 | onShow        | function           | none          | will be called when coachmark is showing                    |
 | onHide        | function           | none          | will be called when coachmark is hidden                     |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export default function AwesomeScreen() {
 ```
 
 ## Example
+
 [![preview](https://i.ibb.co/n3VpkY4/Screen-Shot-2018-12-04-at-13-53-26.png)](https://snack.expo.io/@jekiwijaya/react-native-coachmark)
 
 [View on Expo!](https://snack.expo.io/@jekiwijaya/react-native-coachmark)
@@ -49,20 +50,23 @@ export default function AwesomeScreen() {
 ### - Coachmark
 
 #### Importing
-```javascript
-var Coachmark = require('react-native-coachmark').Coachmark;  // ES5
 
-import { Coachmark } from 'react-native-coachmark';  // ES6
+```javascript
+var Coachmark = require('react-native-coachmark').Coachmark; // ES5
+
+import { Coachmark } from 'react-native-coachmark'; // ES6
 ```
 
 #### Props
-| Property      | Type     | Default Value | Description                                    |
-| ------------- | -------- | ------------- | ---------------------------------------------- |
-| message       | string   | none          | required                                       |
-| autoShow      | boolean  | none          | to show the coachmark when mounting            |
-| onShow        | function | none          | will be called when coachmark is showing       |
-| onHide        | function | none          | will be called when coachmark is hidden        |
-| isAnchorReady | boolean  | true          | a value to force coachmark not being shown yet |
+
+| Property      | Type               | Default Value | Description                                                 |
+| ------------- | ------------------ | ------------- | ----------------------------------------------------------- |
+| message       | string             | none          | required                                                    |
+| autoShow      | boolean            | none          | to show the coachmark when mounting                         |
+| onShow        | function           | none          | will be called when coachmark is showing                    |
+| onHide        | function           | none          | will be called when coachmark is hidden                     |
+| isAnchorReady | boolean            | true          | a value to force coachmark not being shown yet              |
+| renderContent | () => ReactElement | none          | pass a custom coachmark content to override the default one |
 
 #### Methods
 
@@ -71,14 +75,15 @@ import { Coachmark } from 'react-native-coachmark';  // ES6
 | `show() => Promise` | a function to trigger show the coachmark |
 
 ### Roadmap
+
 - [ ] Auto load and save in AsyncStorage
 - [x] Show coachmark only when in view port
 - [ ] Custom render arrow and content
-
 
 ## Contributing
 
 We'd to have your helping hand on this package! Feel free to PR's, add issues or give feedback!
 
 ## Credits
+
 Written by [Jacky Wijaya](https://www.linkedin.com/in/jacky-wijaya-125b90b6/) (jekiwijaya) at Traveloka.

--- a/src/components/Coachmark.tsx
+++ b/src/components/Coachmark.tsx
@@ -149,6 +149,7 @@ export default class Coachmark extends Component<CoachmarkProps, CoachmarkState>
           position={this.state.position}
           message={this.props.message!}
           renderArrow={this.props.renderArrow}
+          renderContent={this.props.renderContent}
         />
       </View>
     );

--- a/src/components/CoachmarkContent.tsx
+++ b/src/components/CoachmarkContent.tsx
@@ -10,7 +10,7 @@ export default class CoachmarkContent extends Component<CoachmarkContentProps> {
     return (
       <View style={styles.container}>
         <View style={styles.message}>
-          <Text style={styles.messageText}>{this.props.message}</Text>
+          <Text style={styles.messageText}>{this.props.message || ''}</Text>
         </View>
         <View style={styles.button}>
           <Text style={styles.buttonText}>{this.props.buttonText}</Text>

--- a/src/components/CoachmarkView.tsx
+++ b/src/components/CoachmarkView.tsx
@@ -10,6 +10,9 @@ export default class CoachmarkView extends Component<CoachmarkViewProps> {
   };
 
   renderCoachmarkContent() {
+    if (this.props.renderContent) {
+      return this.props.renderContent();
+    }
     return <CoachmarkContent message={this.props.message} />;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface CoachmarkArrowProps {
 }
 
 export interface CoachmarkContentProps {
-  message: string;
+  message?: string;
   buttonText?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface CoachmarkProps {
   onShow?: () => void;
   isAnchorReady?: boolean;
   renderArrow?: CoachmarkViewProps['renderArrow'];
+  renderContent?: CoachmarkViewProps['renderContent'];
   accessibilityLabel?: string;
   testID?: string;
   contentContainerStyle?: StyleProp<ViewStyle>;
@@ -36,5 +37,6 @@ export type CoachmarkViewProps = {
     x: number;
     position?: CoachmarkPosition;
   }) => React.ReactElement<CoachmarkArrowProps>;
+  renderContent?: () => React.ReactElement;
 } & CoachmarkContentProps &
   CoachmarkArrowProps;


### PR DESCRIPTION
Adding `renderContent` as prop to enable passing custom content to coachmark
<img src="https://user-images.githubusercontent.com/25707872/139832879-f73fe028-cf0f-429d-8b9a-4828b49d2aeb.jpeg" width="300" />
